### PR TITLE
Fix security vulnerabilities and add Thai-style redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+data/
+

--- a/db.js
+++ b/db.js
@@ -83,11 +83,11 @@ const dbReady = (async ()=>{
 async function createUser({ name, email, password_hash }){
   const now = Date.now();
   const r = await run(`INSERT INTO users(name, email, password_hash, created_at) VALUES(?,?,?,?)`,
-    [name, email, password_hash, now]);
+    [name, email.toLowerCase(), password_hash, now]);
   return r.lastID;
 }
 function getUserByEmail(email){
-  return get(`SELECT * FROM users WHERE email=?`, [email]);
+  return get(`SELECT * FROM users WHERE email=?`, [String(email).toLowerCase()]);
 }
 function getUserById(id){
   return get(`SELECT id,name,email FROM users WHERE id=?`, [id]);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-session": "^1.17.3",
+    "express-rate-limit": "^7.1.5",
     "sqlite3": "^5.1.7"
   },
   "engines": {

--- a/public/analysis.html
+++ b/public/analysis.html
@@ -12,6 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body data-page="analysis">
+  <div class="site-banner">LabCam Web App</div>
   <header class="site-header">
     <div class="brand"><a href="index.html" class="brand-link">LabCam</a></div>
     <button class="hamburger" aria-label="Toggle navigation" aria-controls="site-nav" aria-expanded="false">

--- a/public/csv.html
+++ b/public/csv.html
@@ -13,6 +13,7 @@
   <script defer src="script.js"></script>
 </head>
 <body data-page="csv">
+  <div class="site-banner">LabCam Web App</div>
   <header class="site-header">
     <div class="brand"><a href="index.html" class="brand-link">LabCam</a></div>
     <button class="hamburger" aria-label="Toggle navigation" aria-controls="site-nav" aria-expanded="false">

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body data-page="index">
+  <div class="site-banner">LabCam Web App</div>
   <header class="site-header">
     <div class="brand"><a href="index.html" class="brand-link">LabCam</a></div>
     <button class="hamburger" aria-label="Toggle navigation" aria-controls="site-nav" aria-expanded="false">

--- a/public/login.html
+++ b/public/login.html
@@ -8,6 +8,7 @@
   <script defer src="script.js"></script>
 </head>
 <body data-page="login">
+  <div class="site-banner">LabCam Web App</div>
   <header class="site-header">
     <div class="brand"><a href="index.html" class="brand-link">LabCam</a></div>
   </header>

--- a/public/register.html
+++ b/public/register.html
@@ -8,6 +8,7 @@
   <script defer src="script.js"></script>
 </head>
 <body data-page="register">
+  <div class="site-banner">LabCam Web App</div>
   <header class="site-header">
     <div class="brand"><a href="index.html" class="brand-link">LabCam</a></div>
   </header>

--- a/public/reports.html
+++ b/public/reports.html
@@ -14,6 +14,7 @@
   <script defer src="script.js"></script>
 </head>
 <body data-page="reports">
+  <div class="site-banner">LabCam Web App</div>
   <header class="site-header">
     <div class="brand"><a href="index.html" class="brand-link">LabCam</a></div>
     <button class="hamburger" aria-label="Toggle navigation" aria-controls="site-nav" aria-expanded="false">

--- a/public/style.css
+++ b/public/style.css
@@ -1,25 +1,26 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
+/* Light blue theme inspired by Thai school websites */
 :root{
-  --bg: #0b132b;
-  --bg-soft: #151a30;
-  --card: #111827;
-  --text: #e5e7eb;
-  --muted: #9ca3af;
-  --primary: #2563eb;
-  --primary-2: #1d4ed8;
-  --outline: #334155;
+  --bg: #f8fafc;
+  --bg-soft: #ffffff;
+  --card: #ffffff;
+  --text: #1e293b;
+  --muted: #475569;
+  --primary: #0d6efd;
+  --primary-2: #0b5ed7;
+  --outline: #cbd5e1;
   --danger: #dc2626;
   --success: #16a34a;
-  --shadow: 0 6px 20px rgba(0,0,0,.25);
-  --radius: 14px;
+  --shadow: 0 2px 4px rgba(0,0,0,.1);
+  --radius: 8px;
 }
 
 *{ box-sizing: border-box; }
 html,body{
   margin:0; padding:0;
   color:var(--text);
-  background:linear-gradient(180deg, var(--bg) 0%, #0a0f24 100%);
+  background:var(--bg);
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   line-height:1.5;
 }
@@ -28,20 +29,27 @@ img{ max-width:100%; display:block; }
 .container{ max-width: 1100px; margin: 0 auto; padding: 24px 16px 48px; }
 
 /* Header / Nav */
+.site-banner{
+  background: linear-gradient(90deg, #1e3a8a, #2563eb);
+  color:#fff;
+  text-align:center;
+  padding:20px 0;
+  font-size:1.8rem;
+  font-weight:700;
+}
 .site-header{
   position: sticky; top:0; z-index: 50;
   display:flex; align-items:center; gap:12px;
   padding: 10px 16px;
-  background: rgba(10, 15, 36, .8);
-  backdrop-filter: blur(8px);
-  border-bottom: 1px solid rgba(255,255,255,.06);
+  background: linear-gradient(90deg, #0d47a1, #1976d2);
+  color:#fff;
 }
-.brand-link{ font-weight:700; letter-spacing:.5px; }
+.brand-link{ font-weight:700; letter-spacing:.5px; color:#fff; }
 .navlist{ list-style:none; margin:0; padding:0; display:flex; gap:14px; }
-.navlist a{ padding:8px 12px; border-radius:10px; color: var(--muted); }
-.navlist a.active, .navlist a:hover{ color: var(--text); background: rgba(255,255,255,.05); }
+.navlist a{ padding:8px 12px; border-radius:10px; color: #e0e7ff; }
+.navlist a.active, .navlist a:hover{ color:#fff; background: rgba(255,255,255,.2); }
 .hamburger{ display:none; background:none; border:0; cursor:pointer; padding:8px; }
-.hamburger span{ display:block; width:22px; height:2px; background:var(--text); margin:4px 0; }
+.hamburger span{ display:block; width:22px; height:2px; background:#fff; margin:4px 0; }
 
 /* auth + lang */
 .auth{ display:flex; gap:8px; margin-left:auto; }
@@ -49,7 +57,8 @@ img{ max-width:100%; display:block; }
 
 .site-footer{
   padding: 24px 16px; text-align:center; color:var(--muted);
-  border-top: 1px solid rgba(255,255,255,.06);
+  border-top: 1px solid var(--outline);
+  background: var(--bg-soft);
 }
 
 /* Hero */
@@ -57,15 +66,15 @@ img{ max-width:100%; display:block; }
   padding: 40px 20px;
   text-align: center;
   border-radius: var(--radius);
-  background: radial-gradient(1200px 480px at 50% -40%, rgba(37,99,235,.18), transparent 70%);
+  background: linear-gradient(180deg, #e3f2fd, #ffffff);
 }
 .lead{ color: var(--muted); max-width: 760px; margin: 8px auto 0; }
 .hero-actions{ margin-top: 20px; display:flex; gap:10px; justify-content:center; flex-wrap:wrap; }
 
 /* Cards & layout */
 .card{
-  background: linear-gradient(180deg, rgba(255,255,255,.06), transparent);
-  border: 1px solid rgba(255,255,255,.08);
+  background: var(--card);
+  border: 1px solid var(--outline);
   border-radius: var(--radius);
   padding: 18px;
   box-shadow: var(--shadow);
@@ -78,18 +87,18 @@ img{ max-width:100%; display:block; }
 /* Buttons */
 .btn{
   border: 1px solid var(--outline);
-  background: rgba(255,255,255,.02);
+  background: var(--bg-soft);
   color: var(--text);
   padding: 10px 14px; border-radius: 12px;
   cursor: pointer;
   transition: transform .06s ease, background .2s ease, border-color .2s ease;
 }
-.btn:hover{ transform: translateY(-1px); background: rgba(255,255,255,.05); }
+.btn:hover{ transform: translateY(-1px); background: #f1f5f9; }
 .btn:active{ transform: translateY(0); }
-.btn-primary{ background: linear-gradient(180deg, var(--primary), var(--primary-2)); border-color: transparent; }
-.btn-outline{ background: transparent; border-color: var(--primary); }
-.btn-ghost{ background: transparent; border-color: rgba(255,255,255,.16); color: var(--muted); }
-.btn-danger{ background: linear-gradient(180deg, #ef4444, #dc2626); border-color: transparent; }
+.btn-primary{ background: linear-gradient(180deg, var(--primary), var(--primary-2)); border-color: transparent; color:#fff; }
+.btn-outline{ background: transparent; border-color: var(--primary); color: var(--primary); }
+.btn-ghost{ background: transparent; border-color: var(--outline); color: var(--muted); }
+.btn-danger{ background: linear-gradient(180deg, #ef4444, #dc2626); border-color: transparent; color:#fff; }
 .btn:disabled{ opacity:.6; cursor:not-allowed; }
 
 /* Forms */
@@ -97,8 +106,8 @@ img{ max-width:100%; display:block; }
 label span{ display:block; margin-bottom: 4px; color: var(--muted); }
 input, select{
   width:100%;
-  background: rgba(255,255,255,.04);
-  border:1px solid rgba(255,255,255,.12);
+  background: var(--bg-soft);
+  border:1px solid var(--outline);
   color: var(--text);
   border-radius: 10px;
   padding: 10px 12px;
@@ -113,24 +122,24 @@ input, select{
   width: 100%;
   max-width: 720px;
   aspect-ratio: 4 / 3;
-  background: #0a0f24;
+  background: var(--bg-soft);
   border-radius: 12px;
   overflow: hidden;
-  border: 1px solid rgba(255,255,255,.08);
+  border: 1px solid var(--outline);
 }
 #video, #frameCanvas, #roiCanvas{
   position:absolute; inset:0; width:100%; height:100%;
 }
 #roiCanvas{ pointer-events: auto; }
-.swatch{ display:inline-block; width:16px; height:16px; border-radius:4px; border:1px solid rgba(255,255,255,.3); vertical-align: middle; margin-left: 6px; }
+.swatch{ display:inline-block; width:16px; height:16px; border-radius:4px; border:1px solid var(--outline); vertical-align: middle; margin-left: 6px; }
 .result-box{ display:grid; gap:6px; margin: 8px 0; }
 
 /* Scales editor */
 .scales-editor{ display:grid; gap:10px; margin-top: 10px; }
 .scales-row{ display:flex; gap:8px; flex-wrap: wrap; }
 .codebox{
-  background: rgba(0,0,0,.35);
-  border:1px solid rgba(255,255,255,.08);
+  background: var(--bg-soft);
+  border:1px solid var(--outline);
   border-radius: 10px;
   padding: 10px;
   max-height: 260px; overflow:auto;
@@ -142,9 +151,9 @@ input, select{
 .list{ display:grid; gap:10px; }
 .list .item{
   display:grid; gap:6px;
-  padding: 12px; border:1px solid rgba(255,255,255,.1); border-radius: 10px; background: rgba(255,255,255,.02);
+  padding: 12px; border:1px solid var(--outline); border-radius: 10px; background: var(--bg-soft);
 }
-.badge{ font-size: 12px; padding: 2px 8px; border-radius: 999px; background: rgba(255,255,255,.08); color: var(--muted); }
+.badge{ font-size: 12px; padding: 2px 8px; border-radius: 999px; background: var(--outline); color: var(--muted); }
 
 /* Responsive */
 @media (max-width: 920px){
@@ -153,6 +162,6 @@ input, select{
 @media (max-width: 760px){
   nav{ display:none; }
   .hamburger{ display:block; margin-left:12px; }
-  .navlist{ position:absolute; top:60px; right:12px; flex-direction: column; background: rgba(10,15,36,.98); padding:10px; border-radius: 10px; border:1px solid rgba(255,255,255,.08); display:none; }
+  .navlist{ position:absolute; top:60px; right:12px; flex-direction: column; background: var(--bg-soft); padding:10px; border-radius: 10px; border:1px solid var(--outline); display:none; }
   .navlist.active{ display:flex; }
 }


### PR DESCRIPTION
## Summary
- Randomize session secret when `SESSION_SECRET` is unset
- Add CSRF and rate limiting protections for auth endpoints
- Return 404 instead of 500 when scales are missing
- Normalize user emails to lowercase
- Ensure static assets directory exists and ignore local artifacts
- Apply a light blue theme with a new banner across pages

## Testing
- `npm install` *(fails: 403 Forbidden for express-rate-limit)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b72e95f91483239fc7fc05ff677dfc